### PR TITLE
chore(release): include dist folder in release commit

### DIFF
--- a/.versionrc.js
+++ b/.versionrc.js
@@ -3,4 +3,5 @@ module.exports = {
     prerelease:
       'if [ "$(git branch --show-current)" != "release" ]; then exit 1; fi',
   },
+  commitAll: true,
 };


### PR DESCRIPTION
Just noted in the v19.236.1 release that the dist folder was not added to the releases branch.