### PR TITLE
chore(renovate): don't require approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,7 +27,8 @@
       "packageNames": ["renovate/renovate"],
       "updateTypes": ["major", "minor", "patch"],
       "semanticCommitType": "fix",
-      "automerge": true
+      "automerge": true,
+      "masterIssueApproval": false
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
allow automerge all renovate versions