### PR TITLE
chore: allow lockfile maintenance at any time

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true,
+    "schedule": null,
     "masterIssueApproval": true,
     "automerge": true
   },


### PR DESCRIPTION
Otherwise automerge can be deferred to long after approval