### PR TITLE
chore(deps): update github action runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.3
         with:
           fetch-depth: 0
       - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v1.6.0
+        uses: wagoid/commitlint-github-action@v1.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.3
       - name: Setup node
-        uses: actions/setup-node@v1.4.1
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: '12.x'
       - name: Install project
@@ -58,7 +58,7 @@ jobs:
         configurationFile: [example/renovate-config.js, example/renovate.json]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.3
       - name: Install project
         run: npm ci
       - name: Build
@@ -84,7 +84,7 @@ jobs:
       && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.3.3
         with:
           fetch-depth: 0
           ref: 'release'
@@ -98,7 +98,7 @@ jobs:
         run: |
           git merge -m 'chore(release): merge master (${{ github.sha }})' ${{ github.sha }}
       - name: Setup node
-        uses: actions/setup-node@v1.4.1
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: '12.x'
       - name: Install project
@@ -119,7 +119,7 @@ jobs:
       - name: Publish release
         run: git push --follow-tags
       - name: Publish GitHub release
-        uses: actions/create-release@v1.0.1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Changes:

- Update `actions/checkout` to 2.3.3
- Update `wagoid/commitlint-github-action` to 1.8.0
- Update `actions/setup-node` to 1.4.4
- Update `actions/create-release` to 1.1.4

## Context:

This pull request bumps all GitHub Action runners to the latest stable version that is in range.

I noticed all the GitHub action runners are using outdated versions. I don't know if this is by design or not.
I don't know if Renovate can check for regular GitHub Actions updates?

The `wagoid/commitlint-github-action` actually has a 2.x release with breaking changes.

Quote from [v2.0.0 changelog](https://github.com/wagoid/commitlint-github-action/releases/tag/v2.0.0):
>* `GITHUB_TOKEN` env var is now ignored. In case a custom token is needed,
it'll be necessary to pass it via the token input from now on.
>* this includes breaking changes from commitlint v9,
like the fact that `improvement` type is now rejected in `@commitlint/config-conventional`.

## Release logs for included version upgrades:

https://github.com/actions/checkout/releases/tag/v2.3.3
https://github.com/wagoid/commitlint-github-action/releases/tag/v1.8.0
https://github.com/actions/setup-node/releases/tag/v1.4.4
https://github.com/actions/create-release/releases/tag/v1.1.4

---

**EDIT:** Force pushed a amended commit with a commit message that passes the commit-lint check. :nerd_face:
Also I hope I'm using the right template, I don't know if this is a `chore(deps)` or a `fix(deps)` kind of change.