### PR TITLE
chore: remove obsolete cleanup job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,7 @@ on:
   pull_request:
 
 jobs:
-  cleanup:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: github-cleanup
-        uses: renovatebot/internal-tools@v0
-        continue-on-error: true
-        with:
-          command: github-cleanup
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   commitlint:
-    needs: [cleanup]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,7 +20,6 @@ jobs:
         uses: wagoid/commitlint-github-action@v2.1.0
 
   lint:
-    needs: [cleanup]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,7 +34,6 @@ jobs:
         run: npm run lint
 
   e2e:
-    needs: [cleanup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
no longer needed and does nothing than issue an error bug continues successfully
![image](https://user-images.githubusercontent.com/1798109/97849034-3e6e2000-1cf2-11eb-81ae-79923a99f342.png)
