### PR TITLE
fix(deps): replace `@zeit/ncc`, which is deprecated, with `@vercel/ncc`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -477,10 +477,10 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.27.0.tgz",
+      "integrity": "sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==",
       "dev": true
     },
     "JSONStream": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/node": "13.13.40",
     "@typescript-eslint/eslint-plugin": "4.6.0",
     "@typescript-eslint/parser": "4.6.0",
-    "@zeit/ncc": "0.22.3",
+    "@vercel/ncc": "0.27.0",
     "concurrently": "5.3.0",
     "eslint": "7.12.1",
     "eslint-config-prettier": "7.2.0",


### PR DESCRIPTION
Closes #530.