### PR TITLE
Enable GITHUB_COM_TOKEN environment variable

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -8,7 +8,7 @@ interface EnvironmentVariable {
 
 class Input {
   readonly options = {
-    envRegex: /^(?:RENOVATE_\w+|LOG_LEVEL)$/,
+    envRegex: /^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN)$/,
     configurationFile: {
       input: 'configurationFile',
       env: 'RENOVATE_CONFIG_FILE',


### PR DESCRIPTION
When running this action on a private GitHub Enterprise
with self-hosted runners and you own analyse a golang project
you quickly run into GitHub.com rate-limiting.

According to the docs (https://docs.renovatebot.com/self-hosting/#githubcom-token-for-release-notes)
we need to add the environment variable `GITHUB_COM_TOKEN` to mitigate this.

This was not yet picked up by the docker input parser. This commit will enable `GITHUB_COM_TOKEN` 
to be used for Renovate.