### PR TITLE
docs(readme): update GitHub Action versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2.3.4
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v21.30.0
+        uses: renovatebot/github-action@v25.51.5
         with:
           configurationFile: example/renovate-config.js
           token: ${{ secrets.RENOVATE_TOKEN }}
@@ -117,10 +117,10 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
 
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2.3.4
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v21.30.0
+        uses: renovatebot/github-action@v25.51.5
         with:
           configurationFile: example/renovate-config.js
           token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'


### PR DESCRIPTION
## Changes:

- Update reference to `actions/checkout` to the latest stable release (`2.3.4`)
- Update reference to our `renovatebot/github-action` to use the latest release `v25.51.5`

## Context:

I'm doing this by hand, but maybe we can use the regexManager that Renovate bot has to update these strings in future?
The main Renovate bot repo uses this:

```json
  "regexManagers": [
    {
      "description": "Update Renovate references in Markdown files",
      "fileMatch": ["\\.md$"],
      "matchStrings": [
        "(?<depName>renovate\\/renovate):(?<currentValue>[a-z0-9.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
      ],
      "datasourceTemplate": "docker",
      "versioningTemplate": "docker"
    },
```

Maybe we can adapt that to update our references to GitHub Action runner versions?