### PR TITLE
ci: allow failing commitlint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Lint commit messages
         uses: wagoid/commitlint-github-action@59203cb6ee1ce85035e6fe7b3aa878cf80653739 # renovate: tag=v4.1.1
+        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We can ignore commit lint, as we do squash merge