### PR TITLE
fix: Allow passing through NODE_OPTIONS

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -8,7 +8,7 @@ interface EnvironmentVariable {
 
 class Input {
   readonly options = {
-    envRegex: /^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN)$/,
+    envRegex: /^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS)$/,
     configurationFile: {
       input: 'configurationFile',
       env: 'RENOVATE_CONFIG_FILE',


### PR DESCRIPTION
Renovate is failing in a large repository with the error

```
<--- Last few GCs --->

[9:0x53f4b00]  1875576 ms: Scavenge 1781.0 (1983.4) -> 1779.1 (1999.4) MB, 82.3 / 0.0 ms  (average mu = 0.795, current mu = 0.725) allocation failure 
[9:0x53f4b00]  1875776 ms: Scavenge 1795.0 (1999.4) -> 1795.1 (1999.4) MB, 84.2 / 0.0 ms  (average mu = 0.795, current mu = 0.725) allocation failure 
[9:0x53f4b00]  1875869 ms: Scavenge 1795.1 (1999.4) -> 1793.1 (2015.4) MB, 93.1 / 0.0 ms  (average mu = 0.795, current mu = 0.725) allocation failure 

<--- JS stacktrace --->

FATAL ERROR: MarkCompactCollector: young object promotion failed Allocation failed - JavaScript heap out of memory
 1: 0xa3aaf0 node::Abort() [node]
 2: 0x970199 node::FatalError(char const*, char const*) [node]
 3: 0xbba45e v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
 4: 0xbba7d7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
 5: 0xd769e5  [node]
 6: 0xda737e v8::internal::EvacuateNewSpaceVisitor::Visit(v8::internal::HeapObject, int) [node]
 7: 0xdb33b6 v8::internal::FullEvacuator::RawEvacuatePage(v8::internal::MemoryChunk*, long*) [node]
 8: 0xd9f54f v8::internal::Evacuator::EvacuatePage(v8::internal::MemoryChunk*) [node]
 9: 0xd9f7c8 v8::internal::PageEvacuationTask::RunInParallel(v8::internal::ItemParallelJob::Task::Runner) [node]
10: 0xd920a9 v8::internal::ItemParallelJob::Run() [node]
11: 0xdb5310 void v8::internal::MarkCompactCollectorBase::CreateAndExecuteEvacuationTasks<v8::internal::FullEvacuator, v8::internal::MarkCompactCollector>(v8::internal::MarkCompactCollector*, v8::internal::ItemParallelJob*, v8::internal::MigrationObserver*, long) [node]
12: 0xdb5bac v8::internal::MarkCompactCollector::EvacuatePagesInParallel() [node]
13: 0xdb5d75 v8::internal::MarkCompactCollector::Evacuate() [node]
14: 0xdc7d71 v8::internal::MarkCompactCollector::CollectGarbage() [node]
15: 0xd84038 v8::internal::Heap::MarkCompact() [node]
16: 0xd85b28 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
17: 0xd88f6c v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
18: 0xd4e73d v8::internal::Factory::AllocateRaw(int, v8::internal::AllocationType, v8::internal::AllocationAlignment) [node]
19: 0xd485c4 v8::internal::FactoryBase<v8::internal::Factory>::AllocateRawWithImmortalMap(int, v8::internal::AllocationType, v8::internal::Map, v8::internal::AllocationAlignment) [node]
20: 0xd4a911 v8::internal::FactoryBase<v8::internal::Factory>::NewRawTwoByteString(int, v8::internal::AllocationType) [node]
21: 0x1136eac v8::internal::IncrementalStringBuilder::Extend() [node]
22: 0xe74178 v8::internal::JsonStringifier::SerializeSmi(v8::internal::Smi) [node]
23: 0xe7a328 v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<false>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
24: 0xe7bf57 v8::internal::JsonStringifier::SerializeArrayLikeSlow(v8::internal::Handle<v8::internal::JSReceiver>, unsigned int, unsigned int) [node]
25: 0xe77f4b v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<true>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
26: 0xe77e73 v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<true>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
27: 0xe7addb v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<false>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
28: 0xe78a40 v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<true>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
29: 0xe7addb v8::internal::JsonStringifier::Result v8::internal::JsonStringifier::Serialize_<false>(v8::internal::Handle<v8::internal::Object>, bool, v8::internal::Handle<v8::internal::Object>) [node]
30: 0xe7c79f v8::internal::JsonStringify(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>) [node]
31: 0xc6696f v8::internal::Builtin_JsonStringify(int, unsigned long*, v8::internal::Isolate*) [node]
32: 0x1448ef9  [node]
Error: The process '/usr/bin/docker' failed with exit code 134
```

By passing through `NODE_OPTIONS: '--max_old_space_size=4096'` from GitHub Actions I believe we should be able to increase the memory limit 