### PR TITLE
ci: replace deprecated command with env file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
               | tail +12 \
               | sed -e 's/^\+//' \
               | sed -z 's/\n/%0A/g;s/\r/%0D/g')"
-          echo "::set-output name=changelog::${changelog}"
+          echo "changelog=${changelog}" >> $GITHUB_OUTPUT
       - name: Publish release
         run: git push --follow-tags
       - name: Publish GitHub release


### PR DESCRIPTION
## Description

Resolve #697 

Update `.github/workflows/build.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

**AS-IS**

```yml
echo "::set-output name=changelog::${changelog}"
```

**TO-BE**

```yml
echo "changelog=${changelog}" >> $GITHUB_OUTPUT
```