### PR TITLE
feat!: remove docker socket and change to current user

### DIFF
--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -5,7 +5,6 @@ import fs from 'fs';
 import path from 'path';
 
 class Renovate {
-  private dockerGroupName = 'docker';
   private configFileMountDir = '/github-action';
 
   private docker: Docker;
@@ -17,8 +16,6 @@ class Renovate {
   }
 
   async runDockerContainer(): Promise<void> {
-    const renovateDockerUser = '1000';
-
     const dockerArguments = this.input
       .toEnvironmentVariables()
       .map((e) => `--env ${e.key}`)
@@ -34,9 +31,8 @@ class Renovate {
     }
 
     dockerArguments.push(
-      '--volume /var/run/docker.sock:/var/run/docker.sock',
       '--volume /tmp:/tmp',
-      `--user ${renovateDockerUser}:${this.getDockerGroupId()}`,
+      `--user ${process.env.UID}:0}`,
       '--rm',
       this.docker.image()
     );
@@ -47,35 +43,6 @@ class Renovate {
     if (code !== 0) {
       new Error(`'docker run' failed with exit code ${code}.`);
     }
-  }
-
-  /**
-   * Fetch the host docker group of the GitHub Action runner.
-   *
-   * The Renovate container needs access to this group in order to have the
-   * required permissions on the Docker socket.
-   */
-  private getDockerGroupId(): string {
-    const groupFile = '/etc/group';
-    const groups = fs.readFileSync(groupFile, {
-      encoding: 'utf-8',
-    });
-
-    /**
-     * The group file has `groupname:group-password:GID:username-list` as
-     * structure and we're interested in the `GID` (the group ID).
-     *
-     * Source: https://www.thegeekdiary.com/etcgroup-file-explained/
-     */
-    const re = new RegExp(`^${this.dockerGroupName}:x:([1-9][0-9]*):`, 'm');
-    const match = re.exec(groups);
-    if (!match || match.length < 2) {
-      throw new Error(
-        `Could not find group '${this.dockerGroupName}' in ${groupFile}`
-      );
-    }
-
-    return match[1];
   }
 
   private validateArguments(): void {


### PR DESCRIPTION
BREAKING CHANGE: binary-source is now `install` and the container runs with host user id.