### PR TITLE
fix: use full image again by default

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -14,7 +14,7 @@ class Docker {
       ? tag
         ? `${tag}-slim`
         : 'slim'
-      : tag ?? 'latest';
+      : tag ?? 'full';
   }
 
   image(): string {


### PR DESCRIPTION
`latest` tag now points to the `slim` image.