### PR TITLE
feat!: migrate to node v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   RENOVATE_VERSION: 37.152.1 # renovate: datasource=docker depName=renovate packageName=ghcr.io/renovatebot/renovate
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ inputs:
     required: false
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "src/index.ts",
   "engines": {
-    "node": "^16.13.0 || >=18.12.0",
+    "node": "^20.11.0",
     "yarn": "^1.22.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "src/index.ts",
   "engines": {
-    "node": "^20.11.0",
+    "node": ">=20.11.0",
     "yarn": "^1.22.0"
   },
   "scripts": {


### PR DESCRIPTION
Node v16 is deprecated on GitHub Runners. Node v20 should be used instead.