### PR TITLE
docs: Add another advanced configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ This example uses a Personal Access Token and will run every 15 minutes.
 The Personal Access token is configured as a GitHub secret named `RENOVATE_TOKEN`.
 This example uses the [`example/renovate-config.js`](./example/renovate-config.js) file as configuration.
 Live examples with more advanced configurations of this action can be found in the following repositories:
+
 - [vidavidorra/renovate](https://github.com/vidavidorra/renovate/blob/main/.github/renovate.json)
 - [jenkinsci/helm-charts](https://github.com/jenkinsci/helm-charts/blob/main/.github/renovate-config.json5)
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ See `.github/workflows/build.yml` for an example of how to do this.
 This example uses a Personal Access Token and will run every 15 minutes.
 The Personal Access token is configured as a GitHub secret named `RENOVATE_TOKEN`.
 This example uses the [`example/renovate-config.js`](./example/renovate-config.js) file as configuration.
-You can also see a live example of this action in the [`vidavidorra/github-renovate` repository](https://github.com/vidavidorra/github-renovate) repository, which also includes a more [advanced configuration](https://github.com/vidavidorra/github-renovate/blob/master/src/renovate-config.ts) for updating GitHub Action workflows.
+Live examples with more advanced configurations of this action can be found in the following repositories:
+- [vidavidorra/renovate](https://github.com/vidavidorra/renovate/blob/main/.github/renovate.json)
+- [jenkinsci/helm-charts](https://github.com/jenkinsci/helm-charts/blob/main/.github/renovate-config.json5)
 
 **Remark** Update the action version to the most current, see [here](https://github.com/renovatebot/github-action/releases/latest) for latest release.
 


### PR DESCRIPTION
I recently introduced quite an advanced (if I say so myself) configuration for the official Jenkins Helm Chart using this GitHub Action. It took me quite a lot of trial and error to get everything working, so it might be nice to refer people there looking for a similar configuration. Also, the link to the vidavidorra example didn't work anymore. It also looks like it has been quite simplified, so I'm not sure if it still counts as an advanced configuration.