### PR TITLE
chore: update example files with newer options

### DIFF
--- a/example/renovate-config.js
+++ b/example/renovate-config.js
@@ -4,7 +4,7 @@ module.exports = {
   gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
   onboarding: false,
   platform: 'github',
-  forkProcessing: "enabled",
+  forkProcessing: 'enabled',
   dryRun: 'full',
   repositories: ['renovate-tests/cocoapods1', 'renovate-tests/gomod1'],
   packageRules: [

--- a/example/renovate-config.js
+++ b/example/renovate-config.js
@@ -4,7 +4,7 @@ module.exports = {
   gitAuthor: 'Renovate Bot <bot@renovateapp.com>',
   onboarding: false,
   platform: 'github',
-  includeForks: true,
+  forkProcessing: "enabled",
   dryRun: 'full',
   repositories: ['renovate-tests/cocoapods1', 'renovate-tests/gomod1'],
   packageRules: [
@@ -19,7 +19,7 @@ module.exports = {
         'lockFileMaintenance',
       ],
       dependencyDashboardApproval: false,
-      stabilityDays: 0,
+      minimumReleaseAge: 0,
     },
   ],
 };

--- a/example/renovate-config.json
+++ b/example/renovate-config.json
@@ -5,7 +5,7 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "onboarding": false,
   "platform": "github",
-  "includeForks": true,
+  "forkProcessing": "enabled",
   "repositories": [
     "renovatebot/github-action",
     "renovate-tests/cocoapods1",
@@ -23,7 +23,7 @@
         "lockFileMaintenance"
       ],
       "dependencyDashboardApproval": false,
-      "stabilityDays": 0
+      "minimumReleaseAge": 0
     }
   ]
 }


### PR DESCRIPTION
change includeForks to forkProcessing and stabilityDays to minimumReleaseAge in example global configs.

stabilityDays -> minimumReleaseAge changed by https://github.com/renovatebot/renovate/pull/21376
includeForks -> forkProcessing changed by https://github.com/renovatebot/renovate/pull/20759