### PR TITLE
refactor!: rename docker-cmd-file to docker-entrypoint-file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           configurationFile: ${{ matrix.configurationFile }}
           renovate-version: ${{ env.RENOVATE_VERSION }}
-          docker-cmd-file: example/entrypoint.sh
+          docker-entrypoint-file: example/entrypoint.sh
           docker-user: root
 
   release:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GitHub Action to run Renovate self-hosted.
 - [Badges](#badges)
 - [Options](#options)
   - [`configurationFile`](#configurationfile)
-  - [`docker-cmd-file`](#docker-cmd-file)
+  - [`docker-entrypoint-file`](#docker-entrypoint-file)
   - [`docker-network`](#docker-network)
   - [`docker-socket-host-path`](#docker-socket-host-path)
   - [`docker-user`](#docker-user)
@@ -67,11 +67,10 @@ This disables the requirement of a configuration file for the repository and dis
   requireConfig: false,
 ```
 
-### `docker-cmd-file`
+### `docker-entrypoint-file`
 
-Specify a command to run when the image start.
-By default the image run
-`renovate`.
+Specify an entrypoint file to run when the image starts.
+The default is [renovate-entrypoint.sh](https://github.com/renovatebot/renovate/blob/main/tools/docker/bin/renovate-entrypoint.sh) located in `/usr/local/sbin/renovate-entrypoint.sh`
 This option is useful to customize the image before running `renovate`.
 It must be an existing executable file on the local system.
 It will be mounted to the docker container.
@@ -102,7 +101,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.2.10
         with:
-          docker-cmd-file: .github/renovate-entrypoint.sh
+          docker-entrypoint-file: .github/renovate-entrypoint.sh
           docker-user: root
           token: ${{ secrets.RENOVATE_TOKEN }}
 ```
@@ -124,7 +123,7 @@ Only applicable when `mount-docker-socket` is true.
 
 Specify a user (or user-id) to run docker command.
 
-You can use it with [`docker-cmd-file`](#docker-cmd-file) in order to start the
+You can use it with [`docker-entrypoint-file`](#docker-entrypoint-file) in order to start the
 image as root, do some customization and switch back to a unprivileged user.
 
 ### `docker-volumes`

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ If you want to use the `github-actions` manager, you must setup a [special token
 The Renovate Docker image name to use.
 If omitted or `renovate-image === ''` the action will use the `ghcr.io/renovatebot/renovate` Docker image name otherwise.
 If a Docker image name is defined, the action will use that name to pull the image.
+Note: Use only the image name without a tag, [`renovate-version`](#renovate-version) is used as the image tag.
 
 This sample will use `myproxyhub.domain.com/renovate/renovate` image.
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   env-regex:
     description: |
       Override the environment variables which will be passsed into the renovate container.
-      Defaults to `^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$`
+      Defaults to `^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$`
     required: false
   renovate-version:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -43,9 +43,9 @@ inputs:
       Only applicable when 'mount-docker-socket' is true.
     required: false
     default: /var/run/docker.sock
-  docker-cmd-file:
+  docker-entrypoint-file:
     description: |
-      Override docker command. Default command is `renovate`
+      Override docker docker entrypoint. Use with `docker-user: root`. See the example for usage.
     required: false
   docker-network:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,11 @@ inputs:
     required: false
   renovate-version:
     description: |
-      Renovate version to use. Defaults to latest.
+      Renovate version to use. Also used as image tag together with the parameter `renovate-image`. Defaults to latest.
     required: false
   renovate-image:
     description: |
-      Renovate docker image name.
+      Renovate docker image name. Use the parameter `renovate-version` to set the image tag.
       Defaults to `ghcr.io/renovatebot/renovate`.
     required: false
   mount-docker-socket:

--- a/src/input.ts
+++ b/src/input.ts
@@ -77,9 +77,11 @@ class Input {
     return core.getInput('docker-socket-host-path') || '/var/run/docker.sock';
   }
 
-  getDockerCmdFile(): string | null {
-    const cmdFile = core.getInput('docker-cmd-file');
-    return !!cmdFile && cmdFile !== '' ? path.resolve(cmdFile) : null;
+  getDockerEntrypointFile(): string | null {
+    const entryPointFile = core.getInput('docker-entrypoint-file');
+    return !!entryPointFile && entryPointFile !== ''
+      ? path.resolve(entryPointFile)
+      : null;
   }
 
   getDockerUser(): string | null {

--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -47,12 +47,12 @@ class Renovate {
       );
     }
 
-    const dockerCmdFile = this.input.getDockerCmdFile();
+    const dockerEntryPointFile = this.input.getDockerEntrypointFile();
     let dockerCmd: string | null = null;
-    if (dockerCmdFile !== null) {
-      const baseName = path.basename(dockerCmdFile);
+    if (dockerEntryPointFile !== null) {
+      const baseName = path.basename(dockerEntryPointFile);
       const mountPath = `/${baseName}`;
-      dockerArguments.push(`--volume ${dockerCmdFile}:${mountPath}`);
+      dockerArguments.push(`--volume ${dockerEntryPointFile}:${mountPath}`);
       dockerCmd = mountPath;
     }
 


### PR DESCRIPTION
This should address the comment https://github.com/renovatebot/github-action/issues/817#issuecomment-2391066155

This is a breaking change and requires a major release. 
I am open to changing it to non-breaking change if maintainers wish so.

