### PR TITLE
chore: fix renovate example

### DIFF
--- a/example/renovate-config.js
+++ b/example/renovate-config.js
@@ -19,7 +19,7 @@ module.exports = {
         'lockFileMaintenance',
       ],
       dependencyDashboardApproval: false,
-      minimumReleaseAge: 0,
+      minimumReleaseAge: '0 days',
     },
   ],
 };


### PR DESCRIPTION
Renovate would throw validation error if this property not a string

```
Error type: The renovate configuration file contains some invalid settings
Message: Configuration option packageRules[2].minimumReleaseAge should be a string
```