### PR TITLE
docs(readme): requireConfig now accept required, optional, ignored not boolean.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This disables the requirement of a configuration file for the repository and dis
 
 ```js
   onboarding: false,
-  requireConfig: ignored,
+  requireConfig: 'optional',
 ```
 
 ### `docker-cmd-file`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This disables the requirement of a configuration file for the repository and dis
 
 ```js
   onboarding: false,
-  requireConfig: false,
+  requireConfig: ignored,
 ```
 
 ### `docker-cmd-file`


### PR DESCRIPTION
according [requireConfig](https://docs.renovatebot.com/self-hosted-configuration/#requireconfig) docs, requireConfig now accept `required`, `optional`, `ignored` not boolean.