### PR TITLE
fix: packageRules[0].minimumReleaseAge should be a string

### DIFF
--- a/example/renovate-config.json
+++ b/example/renovate-config.json
@@ -23,7 +23,7 @@
         "lockFileMaintenance"
       ],
       "dependencyDashboardApproval": false,
-      "minimumReleaseAge": 0
+      "minimumReleaseAge": "0"
     }
   ]
 }


### PR DESCRIPTION
Fix to the error I got when using the example renovate-config.json

```       
"errors": [
         {
           "topic": "Configuration Error",
           "message": "Configuration option `packageRules[0].minimumReleaseAge` should be a string"
         }
       ]
```