### PR TITLE
feat: add docker-ssh option to expose SSH credentials to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ GitHub Action to run Renovate self-hosted.
   - [`docker-cmd-file`](#docker-cmd-file)
   - [`docker-network`](#docker-network)
   - [`docker-socket-host-path`](#docker-socket-host-path)
+  - [`docker-ssh`](#docker-ssh)
   - [`docker-user`](#docker-user)
   - [`docker-volumes`](#docker-volumes)
   - [`env-regex`](#env-regex)
@@ -119,6 +120,29 @@ or set it to `host` to run in the same network as github runner, or specify any 
 Allows the overriding of the host path for the Docker socket that is mounted into the container.
 Useful on systems where the host Docker socket is located somewhere other than `/var/run/docker.sock` (the default).
 Only applicable when `mount-docker-socket` is true.
+
+### `docker-ssh`
+
+List of SSH agent socket or keys to expose to the build. This is passed to the Docker container via the `--ssh` flag.
+
+This is useful when Renovate needs to access private repositories or registries via SSH during the build process.
+
+Example usage:
+
+```yml
+....
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v43.0.17
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          docker-ssh: default=${{ env.SSH_AUTH_SOCK }}
+```
 
 ### `docker-user`
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,11 @@ inputs:
       Docker volume mounts. Default to /tmp:/tmp
     default: /tmp:/tmp
     required: false
+  docker-ssh:
+    description: |
+      List of SSH agent socket or keys to expose to the build.
+      This maps to the --ssh flag in docker buildx build.
+    required: false
 
 runs:
   using: node20

--- a/src/input.ts
+++ b/src/input.ts
@@ -96,6 +96,10 @@ export class Input {
     return getInput('docker-network');
   }
 
+  getDockerSsh(): string | null {
+    return getInput('docker-ssh') || null;
+  }
+
   /**
    * Convert to environment variables.
    *

--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -70,6 +70,11 @@ export class Renovate {
       dockerArguments.push(`--network ${dockerNetwork}`);
     }
 
+    const dockerSsh = this.input.getDockerSsh();
+    if (dockerSsh) {
+      dockerArguments.push(`--ssh ${dockerSsh}`);
+    }
+
     dockerArguments.push('--rm', this.docker.image());
 
     if (dockerCmd !== null) {


### PR DESCRIPTION
## Summary

- Added new `docker-ssh` input option to expose SSH agent sockets or keys to the Renovate Docker container
- Passes the value to `docker run` via the `--ssh` flag
- Enables Renovate to access private repositories or registries requiring SSH authentication

## Changes

- **action.yml**: Added `docker-ssh` input parameter with description
- **src/input.ts**: Added `getDockerSsh()` method to retrieve the input value  
- **src/renovate.ts**: Implemented logic to pass `--ssh` flag to docker run command
- **README.md**: Added documentation with usage example in table of contents and dedicated section

## Use Case

This feature is useful when Renovate needs to access private repositories or registries via SSH during the build process. It follows the same pattern as the `ssh` option available in the [docker/build-push-action](https://github.com/docker/build-push-action).

## Example Usage

```yml
- name: Self-hosted Renovate
  uses: renovatebot/github-action@v43.0.17
  with:
    token: ${{ secrets.RENOVATE_TOKEN }}
    docker-ssh: default=${{ env.SSH_AUTH_SOCK }}
```

## Test plan

- [ ] Verify the new input is properly documented in action.yml
- [ ] Confirm the --ssh flag is correctly passed to docker run when the input is provided
- [ ] Test that the option is optional and doesn't break existing workflows when not specified
- [ ] Validate the README documentation is clear and follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)