### PR TITLE
chore(renovate): treat Renovate major version bumps the same

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,13 +40,21 @@
     {
       "description": "Don't pin renovate updates",
       "matchPackageNames": ["ghcr.io/renovatebot/renovate"],
-      "matchFileNames": ["action.yml", "src/docker.ts"],
+      "matchFileNames": [
+        "action.yml",
+        "src/docker.ts",
+        ".github/workflows/build.yml"
+      ],
       "pinDigests": false
     },
     {
       "description": "Use feat! semantic type for renovate major",
       "matchPackageNames": ["ghcr.io/renovatebot/renovate"],
-      "matchFileNames": ["action.yml", "src/docker.ts"],
+      "matchFileNames": [
+        "action.yml",
+        "src/docker.ts",
+        ".github/workflows/build.yml"
+      ],
       "matchUpdateTypes": ["major"],
       "commitMessagePrefix": "feat(deps)!:",
       "additionalBranchPrefix": "renovate-major"


### PR DESCRIPTION
As noticed after the release of v42, we had a couple of PRs (#960
and #961) which were bumping the major version of Renovate, but only one
was treated as a major version.

This makes sure that we're treating them the same, so they get bumped
together.
