### PR TITLE
feat: show Renovate CLI version more prominently in logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,16 @@
+import { group, notice, setFailed } from '@actions/core';
 import { Input } from './input';
 import { Renovate } from './renovate';
-import { setFailed } from '@actions/core';
 
 async function run(): Promise<void> {
   try {
     const input = new Input();
     const renovate = new Renovate(input);
+
+    await group('Check Renovate version', async () => {
+      const version = await renovate.runDockerContainerForVersion();
+      notice(version, { title: 'Renovate CLI version' });
+    });
 
     await renovate.runDockerContainer();
   } catch (error) {

--- a/src/renovate.ts
+++ b/src/renovate.ts
@@ -1,6 +1,6 @@
+import { exec, getExecOutput } from '@actions/exec';
 import { Docker } from './docker';
 import { Input } from './input';
-import { exec } from '@actions/exec';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -12,6 +12,17 @@ export class Renovate {
 
   constructor(private input: Input) {
     this.docker = new Docker(input);
+  }
+
+  async runDockerContainerForVersion(): Promise<string> {
+    const command = `docker run -t --rm ${this.docker.image()} --version`;
+
+    const { exitCode, stdout } = await getExecOutput(command);
+    if (exitCode !== 0) {
+      new Error(`'docker run' failed with exit code ${exitCode}.`);
+    }
+
+    return stdout.trim();
   }
 
   async runDockerContainer(): Promise<void> {


### PR DESCRIPTION
As noted in #969, it would be useful to have a more prominent output in
the logs to indicate the version of the Renovate CLI being used.

This would help with both personal debugging (for administrators of the
GitHub Action) and for raising issues upstream.

To do this, we can call the `--version` on the CLI, capture the output
and report it back to the user.

By using a Notice annotation, we can then make it more visible at the
job- and step-level.

We can then also wrap it in a `group`, so it's hidden in its own
expandable group (with timing information).

Closes #969.
