### PR TITLE
docs: set `RENOVATE_PLATFORM_COMMIT` to `enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ jobs:
 ### Commit signing with GitHub App
 
 Renovate can sign commits when deployed as a GitHub App by utilizing GitHub's API-based commits.
-To activate this, ensure that `platformCommit` is set to `true` in global config.
-If a configuration file is defined, include `platformCommit: true` to activate this feature.
+To activate this, ensure that `platformCommit` is set to `enabled` in global config.
+If a configuration file is defined, include `platformCommit: enabled` to activate this feature.
 For example:
 
 ```yaml
@@ -364,7 +364,7 @@ For example:
   with:
     token: '${{ steps.get_token.outputs.token }}'
   env:
-    RENOVATE_PLATFORM_COMMIT: 'true'
+    RENOVATE_PLATFORM_COMMIT: 'enabled'
 ```
 
 ## Environment Variables


### PR DESCRIPTION
Setting it to `true` still works, but seems to be deprecated. Executing a GHA workflow where I set it to `true` provides the following : ` WARN: env config platformCommit property has been changed to enabled`