### PR TITLE
feat: pass all LOG_* environment variables to the Renovate container

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ jobs:
         with:
           configurationFile: example/renovate-config.js
           token: ${{ secrets.RENOVATE_TOKEN }}
-          env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|AWS_TOKEN)$"
+          env-regex: "^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|AWS_TOKEN)$"
         env:
           AWS_TOKEN: ${{ secrets.AWS_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   env-regex:
     description: |
       Override the environment variables which will be passsed into the renovate container.
-      Defaults to `^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$`
+      Defaults to `^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$`
     required: false
   renovate-version:
     description: |

--- a/src/input.ts
+++ b/src/input.ts
@@ -9,7 +9,7 @@ export interface EnvironmentVariable {
 export class Input {
   readonly options = {
     envRegex:
-      /^(?:RENOVATE_\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$/,
+      /^(?:RENOVATE_\w+|LOG_\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$/,
     configurationFile: {
       input: 'configurationFile',
       env: 'RENOVATE_CONFIG_FILE',


### PR DESCRIPTION
## Description

Renovate supports several logging-related environment variables that are loaded
**before** configuration parsing ([docs](https://docs.renovatebot.com/config-overview/#logging-variables)):

- `LOG_CONTEXT`
- `LOG_FILE`
- `LOG_FILE_FORMAT`
- `LOG_FILE_LEVEL`
- `LOG_FORMAT`
- `LOG_LEVEL`

Currently the default `env-regex` only allows `LOG_LEVEL` through to the
Docker container. Users who want to use `LOG_FILE` (to enable file logging)
must override the entire `env-regex` input just to add one variable.

This PR changes the default pattern from `LOG_LEVEL` to `LOG_\w+` so that
**all** Renovate logging variables are forwarded without requiring users to
customize `env-regex`.

## Changes

- `src/input.ts` — default regex: `LOG_LEVEL` → `LOG_\w+`
- `action.yml` — updated description of the default value
- `README.md` — updated the `env-regex` example

## Motivation

When using `LOG_FILE` with `docker-volumes: /tmp:/tmp` to write Renovate
logs and upload them as artifacts, the log file is never created because
`LOG_FILE` is silently dropped by the action's env filtering.

Example workflow that fails without this change:

```yaml
- name: Self-hosted Renovate
  uses: renovatebot/github-action@v46.1.14
  with:
    configurationFile: .github/renovate-global.json5
    token: ${{ steps.app-token.outputs.token }}
    docker-volumes: /tmp:/tmp
  env:
    LOG_FILE: /tmp/renovate-log.json

- name: Upload Renovate log
  if: always()
  uses: actions/upload-artifact@v4
  with:
    name: renovate-log
    path: /tmp/renovate-log.json
```

The workaround today is to specify a custom `env-regex` that includes
`LOG_FILE`, but this is non-obvious and error-prone since users expect
logging variables to work the same way `LOG_LEVEL` does.