### PR TITLE
docs: use official cache actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,15 +433,15 @@ jobs:
 
 ## Persisting the repository cache
 
-In some cases, Renovate can update PRs more frequently than you expect. The [repository cache](https://docs.renovatebot.com/self-hosted-configuration/#repositorycache) can help with this issue. You need a few things to persist this cache in GitHub actions:
+In some cases, Renovate can update PRs more frequently than you expect. The [repository cache](https://docs.renovatebot.com/self-hosted-configuration/#repositorycache) can help with this issue. You need a few things to persist this cache in GitHub Actions:
 
 1. Enable the `repositoryCache` [option](https://docs.renovatebot.com/self-hosted-configuration/#repositorycache) via env vars or renovate.json.
-2. Persist `/tmp/renovate/cache/renovate/repository` as an artifact.
-3. Restore the artifact before renovate runs.
+2. Restore `/tmp/renovate/cache/renovate/repository` before Renovate runs.
+3. Save the updated directory under a new cache key after Renovate finishes.
 
 Below is a workflow example with caching.
 
-Note that while archiving and compressing the cache is more performant, especially if you need to handle lots of files within the cache, it's not strictly necessary. You could simplify this workflow and only upload and download a single artifact file (or directory) with a direct path (e.g. `/tmp/renovate/cache/renovate/repository/github/$org/$repo.json`). However, you'll still need to set the correct permissions with `chown` as shown in the example.
+The primary key includes `github.run_id` and `github.run_attempt`, so each successful run or rerun can save its updated cache. `restore-keys` selects the most recent prior cache. The ownership fix is still required because the restored files are created by the runner but Renovate reads them inside its container as user `12021`.
 
 ```yml
 name: Renovate
@@ -463,12 +463,11 @@ on:
 
 # Adding these as env variables makes it easy to re-use them in different steps and in bash.
 env:
-  cache_archive: renovate_cache.tar.gz
   # This is the dir renovate provides -- if we set our own directory via cacheDir, we can run into permissions issues.
   # It is also possible to cache a higher level of the directory, but it has minimal benefit. While renovate execution
   # time gets faster, it also takes longer to upload the cache as it grows bigger.
   cache_dir: /tmp/renovate/cache/renovate/repository
-  # This can be manually changed to bust the cache if neccessary.
+  # This can be manually changed to bust the cache if necessary.
   cache_key: renovate-cache
 
 jobs:
@@ -476,40 +475,21 @@ jobs:
     name: Renovate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.3
 
-      # This third party action allows you to download the cache artifact from different workflow runs
-      # Note that actions/cache doesn't work well because the cache key would need to be computed from
-      # a file within the cache, meaning there would never be any data to restore. With other keys, the
-      # cache wouldn't necessarily upload when it changes. actions/download-artifact also doesn't work
-      # because it only handles artifacts uploaded in the same run, and we want to restore from the
-      # previous successful run.
-      - uses: dawidd6/action-download-artifact@v2
-        if: github.event.inputs.repoCache != 'disabled'
-        continue-on-error: true
+      - name: Restore renovate cache
+        id: cache-restore
+        if: github.event.inputs.repoCache != 'disabled' && github.event.inputs.repoCache != 'reset'
+        uses: actions/cache/restore@v6.1.0
         with:
-          name: ${{ env.cache_key }}
-          path: cache-download
+          path: ${{ env.cache_dir }}
+          key: ${{ env.cache_key }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ env.cache_key }}-
 
-      # Using tar to compress and extract the archive isn't strictly necessary, but it can improve
-      # performance significantly when uploading artifacts with lots of files.
-      - name: Extract renovate cache
+      - name: Fix restored cache ownership
+        if: steps.cache-restore.outputs.cache-matched-key != ''
         run: |
-          set -x
-          # Skip if no cache is set, such as the first time it runs.
-          if [ ! -d cache-download ] ; then
-            echo "No cache found."
-            exit 0
-          fi
-
-          # Make sure the directory exists, and extract it there. Note that it's nested in the download directory.
-          mkdir -p $cache_dir
-          tar -xzf cache-download/$cache_archive -C $cache_dir
-
-          # Unfortunately, the permissions expected within renovate's docker container
-          # are different than the ones given after the cache is restored. We have to
-          # change ownership to solve this. We also need to have correct permissions in
-          # the entire /tmp/renovate tree, not just the section with the repo cache.
           sudo chown -R 12021:0 /tmp/renovate/
           ls -R $cache_dir
 
@@ -522,24 +502,12 @@ jobs:
           # This enables the cache -- if this is set, it's not necessary to add it to renovate.json.
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
 
-      # Compression helps performance in the upload step!
-      - name: Compress renovate cache
-        run: |
-          ls $cache_dir
-          # The -C is important -- otherwise we end up extracting the files with
-          # their full path, ultimately leading to a nested directory situation.
-          # To solve *that*, we'd have to extract to root (/), which isn't safe.
-          tar -czvf $cache_archive -C $cache_dir .
-
-      - uses: actions/upload-artifact@v3
-        if: github.event.inputs.repoCache != 'disabled'
+      - name: Save renovate cache
+        if: github.event.inputs.repoCache != 'disabled' && steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6.1.0
         with:
-          name: ${{ env.cache_key }}
-          path: ${{ env.cache_archive }}
-          # Since this is updated and restored on every run, we don't need to keep it
-          # for long. Just make sure this value is large enough that multiple renovate
-          # runs can happen before older cache archives are deleted.
-          retention-days: 1
+          path: ${{ env.cache_dir }}
+          key: ${{ env.cache_key }}-${{ github.run_id }}-${{ github.run_attempt }}
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Closes #827

## Summary

- replace the third-party artifact download/upload flow with the official `actions/cache/restore` and `actions/cache/save` actions
- use per-run and per-attempt primary keys plus a stable restore prefix so the mutable Renovate cache is restored from the newest prior run and saved under a fresh immutable key
- retain the required UID `12021` ownership correction, gated on an actual exact or partial restore
- preserve the existing `enabled`, `disabled`, and `reset` workflow-dispatch behavior
- remove the manual tar archive and update the stale checkout action in the example

The unique key is necessary because GitHub cache entries are immutable. Including `github.run_attempt` also lets a rerun save an updated cache without colliding with the previous attempt.

## Validation

- extracted cache workflow parses as YAML
- `pnpm lint` passes, including ESLint and repository-pinned Prettier
- verified the documented inputs and `cache-hit` / `cache-matched-key` outputs against `actions/cache` v6.1.0
- `git diff --check` passes
