### PR TITLE
docs: recommend custom environment prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ For example:
 
 ## Environment Variables
 
-If you wish to pass through environment variables through to the Docker container that powers this action you need to prefix the environment variable with `RENOVATE_`.
+Environment variables prefixed with `RENOVATE_` are passed through to the Docker container automatically. This prefix is reserved for [Renovate self-hosted configuration](https://docs.renovatebot.com/self-hosted-configuration/), so using it for unrelated credentials can accidentally conflict with a Renovate option.
+
+For custom credentials, use a distinct prefix and add the variable to [`env-regex`](#passing-other-environment-variables).
 
 For example if you wish to pass through some credentials for a [host rule](https://docs.renovatebot.com/configuration-options/#hostrules) to the `config.js` then you should do so like this.
 
@@ -389,8 +391,9 @@ For example if you wish to pass through some credentials for a [host rule](https
            with:
              configurationFile: example/renovate-config.js
              token: ${{ secrets.RENOVATE_TOKEN }}
+             env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL|GITHUB_COM_TOKEN|NODE_OPTIONS|NO_COLOR|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy|CUSTOM_TFE_TOKEN)$"
            env:
-             RENOVATE_TFE_TOKEN: ${{ secrets.MY_TFE_TOKEN }}
+             CUSTOM_TFE_TOKEN: ${{ secrets.MY_TFE_TOKEN }}
    ```
 
 1. In `example/renovate-config.js` include the hostRules block
@@ -401,7 +404,7 @@ For example if you wish to pass through some credentials for a [host rule](https
        {
          hostType: 'terraform-module',
          matchHost: 'app.terraform.io',
-         token: process.env.RENOVATE_TFE_TOKEN,
+         token: process.env.CUSTOM_TFE_TOKEN,
        },
      ],
    };


### PR DESCRIPTION
## Summary

- explain that `RENOVATE_` is reserved for Renovate self-hosted configuration
- recommend a distinct prefix for unrelated credentials
- update the host-rule example to use `CUSTOM_TFE_TOKEN`
- extend `env-regex` with that variable while preserving the complete current default expression

## Why

Using `RENOVATE_` for an arbitrary credential can collide with Renovate configuration environment variables. A separate prefix avoids that ambiguity, but the action must explicitly pass the variable into its container.

Closes #850.

## Validation

- Prettier check for `README.md`
- whitespace and patch validation
